### PR TITLE
Adiciona preview de assets

### DIFF
--- a/__tests__/preview/previewRoute.test.ts
+++ b/__tests__/preview/previewRoute.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { buildPreviewRoute, isPreviewRoute, parsePreviewRoute } from "../../src/preview/previewRoute"
+
+describe("preview route helpers", () => {
+    it("detects preview routes", () => {
+        expect(isPreviewRoute("/preview")).toBe(true)
+        expect(isPreviewRoute("/preview/creature-rokmora")).toBe(true)
+        expect(isPreviewRoute("/")).toBe(false)
+        expect(isPreviewRoute("/game/preview")).toBe(false)
+    })
+
+    it("parses compact type-name routes", () => {
+        expect(parsePreviewRoute("/preview/creature-rokmora")).toEqual({ type: "creature", name: "rokmora" })
+        expect(parsePreviewRoute("/preview/fx-flame_cleave")).toEqual({ type: "fx", name: "flame_cleave" })
+    })
+
+    it("parses slash-separated type/name routes", () => {
+        expect(parsePreviewRoute("/preview/portrait/yue")).toEqual({ type: "portrait", name: "yue" })
+    })
+
+    it("ignores invalid asset types", () => {
+        expect(parsePreviewRoute("/preview/item-sword")).toBeUndefined()
+        expect(parsePreviewRoute("/preview/creature-")).toBeUndefined()
+        expect(parsePreviewRoute("/preview")).toBeUndefined()
+    })
+
+    it("builds canonical compact routes", () => {
+        expect(buildPreviewRoute({ type: "portrait", name: "yue" })).toBe("/preview/portrait-yue")
+        expect(buildPreviewRoute({ type: "fx", name: "flame_cleave" })).toBe("/preview/fx-flame_cleave")
+    })
+})

--- a/aicontext/ui-asset-preview.md
+++ b/aicontext/ui-asset-preview.md
@@ -1,0 +1,20 @@
+# UI Asset Preview
+
+## Features
+
+### Preview Route
+The React app exposes a development-oriented `/preview` route for visual inspection of local public assets without starting the main game scene. The route accepts an optional selected asset in the canonical compact form `/preview/<type>-<name>`, where `type` is `creature`, `portrait`, or `fx`. It also accepts `/preview/<type>/<name>` when loading directly so older links and ad hoc examples can still initialize the same selection.
+
+The preview page owns its URL state through browser history. Selecting an item in the sidebar updates the path to the compact route, and browser back/forward rehydrates the selected asset from the URL.
+
+### Asset Manifest
+Previewable assets are discovered at Vite dev/build time by a virtual manifest module. The manifest scans public creature SVG spritesheets, portrait images, and FX SVG spritesheets, then exposes their public asset paths to the React preview UI. This keeps the preview list aligned with files under `public/assets` without moving visual assets into `src` or hardcoding filenames in React components.
+
+### Rendering Contract
+Creature SVG spritesheets are rendered in an isolated Phaser instance created only for the preview page. The preview loads the selected SVG as a fixed-frame spritesheet and displays every standard creature action/direction animation simultaneously in a labeled grid.
+
+Portrait previews render as a static image because portraits are already final still assets.
+
+FX SVG spritesheets are rendered in the same isolated Phaser preview path as a single looping animation, following the linear FX spritesheet contract.
+
+The preview Phaser game is destroyed when the selected animated asset changes or when the React component unmounts, so it does not share state, scenes, listeners, timers, or textures with the main Grim Fight runtime.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,20 @@ import { IRefPhaserGame, PhaserGame } from "./PhaserGame"
 import { Ui } from "./ui/Ui"
 import { EventBus } from "./game/tools/EventBus"
 import { MainMenu } from "./ui/MainMenu/MainMenu"
+import { PreviewPage } from "./preview/PreviewPage"
+import { isPreviewRoute } from "./preview/previewRoute"
 
 type AppState = "menu" | "loading" | "playing"
 
 function App() {
+    if (isPreviewRoute(window.location.pathname)) {
+        return <PreviewPage />
+    }
+
+    return <GameApp />
+}
+
+function GameApp() {
     const [appState, setAppState] = useState<AppState>("menu")
     //  References to the PhaserGame component (game and scene are exposed)
     const phaserRef = useRef<IRefPhaserGame | null>(null)

--- a/src/preview/PreviewPage.tsx
+++ b/src/preview/PreviewPage.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from "react"
+import { Box, Button, Chip, Divider, List, ListItemButton, ListItemText, Stack, Tab, Tabs, ThemeProvider, Typography } from "@mui/material"
+import { useMuiTheme } from "../ui/hooks/useMuiTheme"
+import { buildPreviewRoute, parsePreviewRoute, type PreviewAssetType } from "./previewRoute"
+import { findPreviewAsset, getFirstAvailablePreviewAsset, getFirstPreviewAsset, previewAssetLabels, previewAssets, type PreviewAsset } from "./previewAssets"
+import { PreviewPhaserCanvas } from "./PreviewPhaserCanvas"
+
+function getAssetFromLocation(): PreviewAsset | undefined {
+    const parsed = parsePreviewRoute(window.location.pathname)
+    if (!parsed) return getFirstAvailablePreviewAsset()
+
+    return findPreviewAsset(parsed.type, parsed.name) ?? getFirstPreviewAsset(parsed.type) ?? getFirstAvailablePreviewAsset()
+}
+
+export function PreviewPage() {
+    const theme = useMuiTheme()
+    const [selectedAsset, setSelectedAsset] = useState<PreviewAsset | undefined>(() => getAssetFromLocation())
+    const [activeType, setActiveType] = useState<PreviewAssetType>(() => selectedAsset?.type ?? "creature")
+
+    useEffect(() => {
+        const updateFromLocation = () => {
+            const asset = getAssetFromLocation()
+            setSelectedAsset(asset)
+            if (asset) setActiveType(asset.type)
+        }
+
+        window.addEventListener("popstate", updateFromLocation)
+        return () => window.removeEventListener("popstate", updateFromLocation)
+    }, [])
+
+    const selectAsset = (asset: PreviewAsset) => {
+        setSelectedAsset(asset)
+        setActiveType(asset.type)
+        window.history.pushState(null, "", buildPreviewRoute(asset))
+    }
+
+    const selectType = (type: PreviewAssetType) => {
+        setActiveType(type)
+        const firstAsset = getFirstPreviewAsset(type)
+        if (firstAsset) selectAsset(firstAsset)
+    }
+
+    return (
+        <ThemeProvider theme={theme}>
+            <Box
+                sx={{
+                    minHeight: "100vh",
+                    width: 1,
+                    bgcolor: "#070910",
+                    color: "#f8fafc",
+                    display: { xs: "block", md: "flex" },
+                }}
+            >
+                <Box
+                    component="aside"
+                    sx={{
+                        width: { xs: 1, md: 320 },
+                        maxHeight: { xs: "44vh", md: "100vh" },
+                        overflow: "hidden",
+                        borderRight: { md: "1px solid rgba(148, 163, 184, 0.22)" },
+                        borderBottom: { xs: "1px solid rgba(148, 163, 184, 0.22)", md: 0 },
+                        bgcolor: "rgba(15, 23, 42, 0.78)",
+                        display: "flex",
+                        flexDirection: "column",
+                    }}
+                >
+                    <Box sx={{ px: 2.5, py: 2 }}>
+                        <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+                            <Typography variant="h6">Asset Preview</Typography>
+                            {selectedAsset && <Chip size="small" label={selectedAsset.type} variant="outlined" />}
+                        </Stack>
+                    </Box>
+                    <Tabs value={activeType} onChange={(_, value: PreviewAssetType) => selectType(value)} variant="fullWidth">
+                        <Tab value="creature" label="Creatures" />
+                        <Tab value="portrait" label="Portraits" />
+                        <Tab value="fx" label="FX" />
+                    </Tabs>
+                    <Divider />
+                    <List sx={{ overflow: "auto", py: 0 }}>
+                        {previewAssets[activeType].map((asset) => (
+                            <ListItemButton
+                                key={`${asset.type}-${asset.name}`}
+                                selected={selectedAsset?.type === asset.type && selectedAsset.name === asset.name}
+                                onClick={() => selectAsset(asset)}
+                            >
+                                <ListItemText primary={asset.label} secondary={asset.path} secondaryTypographyProps={{ noWrap: true }} />
+                            </ListItemButton>
+                        ))}
+                        {previewAssets[activeType].length === 0 && (
+                            <Box sx={{ p: 2.5 }}>
+                                <Typography variant="body2" color="text.secondary">
+                                    Nenhum asset em {previewAssetLabels[activeType]}.
+                                </Typography>
+                            </Box>
+                        )}
+                    </List>
+                </Box>
+
+                <Box component="main" sx={{ flex: 1, minWidth: 0, minHeight: { xs: "56vh", md: "100vh" }, display: "flex", flexDirection: "column" }}>
+                    {selectedAsset ? <SelectedAssetPreview asset={selectedAsset} /> : <EmptyPreview />}
+                </Box>
+            </Box>
+        </ThemeProvider>
+    )
+}
+
+function SelectedAssetPreview({ asset }: { asset: PreviewAsset }) {
+    return (
+        <Box sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", p: { xs: 2, md: 4 }, gap: 2 }}>
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={1.5} alignItems={{ xs: "flex-start", sm: "center" }} justifyContent="space-between">
+                <Box>
+                    <Typography variant="h4" sx={{ lineHeight: 1.05 }}>
+                        {asset.name}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                        {asset.path}
+                    </Typography>
+                </Box>
+                <Button variant="outlined" href="/">
+                    Voltar ao jogo
+                </Button>
+            </Stack>
+
+            <Box
+                sx={{
+                    flex: 1,
+                    minHeight: 360,
+                    border: "1px solid rgba(148, 163, 184, 0.22)",
+                    borderRadius: 3,
+                    overflow: "hidden",
+                    bgcolor: "#10131c",
+                }}
+            >
+                {asset.type === "portrait" ? <PortraitPreview asset={asset} /> : <PreviewPhaserCanvas key={`${asset.type}-${asset.name}`} asset={asset} />}
+            </Box>
+        </Box>
+    )
+}
+
+function PortraitPreview({ asset }: { asset: PreviewAsset }) {
+    return (
+        <Box sx={{ height: 1, minHeight: 360, display: "grid", placeItems: "center", background: "radial-gradient(circle at center, #1e293b 0, #10131c 58%)" }}>
+            <Box
+                component="img"
+                src={asset.path}
+                alt={asset.name}
+                sx={{
+                    width: { xs: 192, md: 320 },
+                    height: { xs: 192, md: 320 },
+                    imageRendering: "pixelated",
+                    borderRadius: 4,
+                    border: "1px solid rgba(248, 250, 252, 0.18)",
+                    boxShadow: "0 24px 80px rgba(0, 0, 0, 0.45)",
+                }}
+            />
+        </Box>
+    )
+}
+
+function EmptyPreview() {
+    return (
+        <Box sx={{ flex: 1, display: "grid", placeItems: "center", p: 4 }}>
+            <Typography color="text.secondary">Nenhum asset disponivel para preview.</Typography>
+        </Box>
+    )
+}

--- a/src/preview/PreviewPhaserCanvas.tsx
+++ b/src/preview/PreviewPhaserCanvas.tsx
@@ -1,0 +1,146 @@
+import { useLayoutEffect, useRef } from "react"
+import * as Phaser from "phaser"
+import type { PreviewAsset } from "./previewAssets"
+import { creaturePreviewAnimations, creaturePreviewDirections, creaturePreviewTotalFramesPerRow, fxPreviewFrameCount } from "./previewAnimations"
+
+interface PreviewPhaserCanvasProps {
+    asset: PreviewAsset
+}
+
+class AssetPreviewScene extends Phaser.Scene {
+    constructor(private readonly asset: PreviewAsset) {
+        super(`AssetPreviewScene-${asset.type}-${asset.name}`)
+    }
+
+    preload(): void {
+        this.load.spritesheet(this.textureKey, this.asset.path, {
+            frameWidth: 64,
+            frameHeight: 64,
+        })
+    }
+
+    create(): void {
+        this.cameras.main.setBackgroundColor("#10131c")
+
+        if (this.asset.type === "creature") {
+            this.createCreaturePreview()
+            return
+        }
+
+        this.createFxPreview()
+    }
+
+    private get textureKey(): string {
+        return `preview-${this.asset.type}-${this.asset.name}`
+    }
+
+    private createCreaturePreview(): void {
+        const cellWidth = 220
+        const cellHeight = 126
+        const startX = 150
+        const startY = 94
+
+        this.add
+            .text(24, 18, `${this.asset.name} creature spritesheet`, {
+                color: "#f8fafc",
+                fontFamily: "monospace",
+                fontSize: "18px",
+            })
+            .setDepth(2)
+
+        for (const [row, animation] of creaturePreviewAnimations.entries()) {
+            for (const [column, direction] of creaturePreviewDirections.entries()) {
+                const x = startX + column * cellWidth
+                const y = startY + row * cellHeight
+                const startingFrame = animation.startingFrame + column * creaturePreviewTotalFramesPerRow
+                const animationKey = `${this.textureKey}-${animation.key}-${direction}`
+
+                this.drawCell(x, y, cellWidth - 18, cellHeight - 14)
+                this.addLabel(`${animation.key} ${direction}`, x, y - 48)
+
+                if (!this.anims.exists(animationKey)) {
+                    this.anims.create({
+                        key: animationKey,
+                        frames: this.anims.generateFrameNumbers(this.textureKey, {
+                            start: startingFrame,
+                            end: startingFrame + animation.usedFramesPerRow - 1,
+                        }),
+                        frameRate: animation.usedFramesPerRow + 1,
+                        repeat: -1,
+                    })
+                }
+
+                this.add.sprite(x, y + 12, this.textureKey).setScale(2).play(animationKey)
+            }
+        }
+    }
+
+    private createFxPreview(): void {
+        const animationKey = `${this.textureKey}-loop`
+        if (!this.anims.exists(animationKey)) {
+            this.anims.create({
+                key: animationKey,
+                frames: this.anims.generateFrameNumbers(this.textureKey, { start: 0, end: fxPreviewFrameCount - 1 }),
+                frameRate: 15,
+                repeat: -1,
+            })
+        }
+
+        this.add
+            .text(24, 18, `${this.asset.name} FX spritesheet`, {
+                color: "#f8fafc",
+                fontFamily: "monospace",
+                fontSize: "18px",
+            })
+            .setDepth(2)
+        this.drawCell(360, 260, 260, 220)
+        this.addLabel("loop", 360, 168)
+        this.add.sprite(360, 280, this.textureKey).setScale(4).play(animationKey)
+    }
+
+    private drawCell(centerX: number, centerY: number, width: number, height: number): void {
+        this.add.rectangle(centerX, centerY, width, height, 0x171b27, 0.88).setStrokeStyle(1, 0x334155, 0.8)
+    }
+
+    private addLabel(label: string, x: number, y: number): void {
+        this.add
+            .text(x, y, label, {
+                color: "#cbd5e1",
+                fontFamily: "monospace",
+                fontSize: "13px",
+            })
+            .setOrigin(0.5)
+            .setDepth(2)
+    }
+}
+
+export function PreviewPhaserCanvas({ asset }: PreviewPhaserCanvasProps) {
+    const containerRef = useRef<HTMLDivElement | null>(null)
+
+    useLayoutEffect(() => {
+        const container = containerRef.current
+        if (!container) return undefined
+
+        const game = new Phaser.Game({
+            type: Phaser.AUTO,
+            parent: container,
+            width: asset.type === "creature" ? 960 : 720,
+            height: asset.type === "creature" ? 700 : 560,
+            transparent: false,
+            antialias: true,
+            scene: new AssetPreviewScene(asset),
+            scale: {
+                mode: Phaser.Scale.FIT,
+                autoCenter: Phaser.Scale.CENTER_BOTH,
+            },
+            render: { antialias: true },
+            fps: { target: 60, smoothStep: true },
+        })
+
+        return () => {
+            game.destroy(true)
+        }
+    }, [asset])
+
+    return <div ref={containerRef} style={{ width: "100%", height: "100%", minHeight: 360 }} />
+}

--- a/src/preview/previewAnimations.ts
+++ b/src/preview/previewAnimations.ts
@@ -1,0 +1,12 @@
+export const creaturePreviewDirections = ["up", "left", "down", "right"] as const
+
+export const creaturePreviewAnimations = [
+    { key: "idle", startingFrame: 0, usedFramesPerRow: 2 },
+    { key: "walking", startingFrame: 36, usedFramesPerRow: 9 },
+    { key: "attacking1", startingFrame: 72, usedFramesPerRow: 8 },
+    { key: "attacking2", startingFrame: 108, usedFramesPerRow: 6 },
+    { key: "casting", startingFrame: 144, usedFramesPerRow: 7 },
+] as const
+
+export const creaturePreviewTotalFramesPerRow = 9
+export const fxPreviewFrameCount = 10

--- a/src/preview/previewAssets.ts
+++ b/src/preview/previewAssets.ts
@@ -1,0 +1,37 @@
+import manifest from "virtual:asset-preview-manifest"
+import type { PreviewAssetType } from "./previewRoute"
+
+export interface PreviewAsset {
+    type: PreviewAssetType
+    name: string
+    label: string
+    path: string
+}
+
+export const previewAssetLabels: Record<PreviewAssetType, string> = {
+    creature: "Creatures",
+    portrait: "Portraits",
+    fx: "FX",
+}
+
+const creatures: PreviewAsset[] = manifest.creatures.map((asset) => ({ ...asset, type: "creature" }))
+const portraits: PreviewAsset[] = manifest.portraits.map((asset) => ({ ...asset, type: "portrait" }))
+const fx: PreviewAsset[] = manifest.fx.map((asset) => ({ ...asset, type: "fx" }))
+
+export const previewAssets: Record<PreviewAssetType, PreviewAsset[]> = {
+    creature: creatures,
+    portrait: portraits,
+    fx,
+}
+
+export function findPreviewAsset(type: PreviewAssetType, name: string): PreviewAsset | undefined {
+    return previewAssets[type].find((asset) => asset.name === name)
+}
+
+export function getFirstPreviewAsset(type: PreviewAssetType): PreviewAsset | undefined {
+    return previewAssets[type][0]
+}
+
+export function getFirstAvailablePreviewAsset(): PreviewAsset | undefined {
+    return getFirstPreviewAsset("creature") ?? getFirstPreviewAsset("portrait") ?? getFirstPreviewAsset("fx")
+}

--- a/src/preview/previewRoute.ts
+++ b/src/preview/previewRoute.ts
@@ -1,0 +1,42 @@
+export const previewAssetTypes = ["creature", "portrait", "fx"] as const
+
+export type PreviewAssetType = (typeof previewAssetTypes)[number]
+
+export interface PreviewRouteSelection {
+    type: PreviewAssetType
+    name: string
+}
+
+export function isPreviewAssetType(value: string): value is PreviewAssetType {
+    return previewAssetTypes.includes(value as PreviewAssetType)
+}
+
+export function isPreviewRoute(pathname: string): boolean {
+    return pathname.split("/").filter(Boolean)[0] === "preview"
+}
+
+export function parsePreviewRoute(pathname: string): PreviewRouteSelection | undefined {
+    const segments = pathname.split("/").filter(Boolean).map((segment) => decodeURIComponent(segment))
+    if (segments[0] !== "preview") return undefined
+
+    const compactParam = segments[1]
+    if (!compactParam) return undefined
+
+    if (isPreviewAssetType(compactParam) && segments[2]) {
+        return { type: compactParam, name: segments[2] }
+    }
+
+    const separatorIndex = compactParam.indexOf("-")
+    if (separatorIndex <= 0) return undefined
+
+    const type = compactParam.slice(0, separatorIndex)
+    const name = compactParam.slice(separatorIndex + 1)
+    if (!isPreviewAssetType(type) || !name) return undefined
+
+
+    return { type, name }
+}
+
+export function buildPreviewRoute(selection: PreviewRouteSelection): string {
+    return `/preview/${selection.type}-${encodeURIComponent(selection.name)}`
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,18 @@
 /// <reference types="vite/client" />
+
+declare module "virtual:asset-preview-manifest" {
+    export interface PreviewAssetManifestItem {
+        name: string
+        label: string
+        path: string
+    }
+
+    export interface PreviewAssetManifest {
+        creatures: PreviewAssetManifestItem[]
+        portraits: PreviewAssetManifestItem[]
+        fx: PreviewAssetManifestItem[]
+    }
+
+    const manifest: PreviewAssetManifest
+    export default manifest
+}

--- a/vite/assetPreviewManifest.mjs
+++ b/vite/assetPreviewManifest.mjs
@@ -1,0 +1,65 @@
+import fs from "node:fs"
+import path from "node:path"
+
+const virtualModuleId = "virtual:asset-preview-manifest"
+const resolvedVirtualModuleId = `\0${virtualModuleId}`
+
+const assetRoots = {
+    creatures: "public/assets/spritesheets/characters",
+    portraits: "public/assets/portraits",
+    fx: "public/assets/particles",
+}
+
+const extensions = {
+    creatures: new Set([".svg"]),
+    portraits: new Set([".webp", ".png", ".jpg", ".jpeg", ".svg"]),
+    fx: new Set([".svg"]),
+}
+
+function toAssetUrl(filePath) {
+    const relativePath = path.relative(path.resolve(process.cwd(), "public"), filePath).replaceAll(path.sep, "/")
+    return `/${relativePath}`
+}
+
+function collectAssets(kind) {
+    const root = path.resolve(process.cwd(), assetRoots[kind])
+    if (!fs.existsSync(root)) return []
+
+    return fs
+        .readdirSync(root, { withFileTypes: true })
+        .filter((entry) => entry.isFile())
+        .map((entry) => {
+            const extension = path.extname(entry.name).toLowerCase()
+            if (!extensions[kind].has(extension)) return undefined
+
+            const name = path.basename(entry.name, path.extname(entry.name))
+            return {
+                name,
+                label: name,
+                path: toAssetUrl(path.join(root, entry.name)),
+            }
+        })
+        .filter(Boolean)
+        .sort((left, right) => left.name.localeCompare(right.name, undefined, { sensitivity: "base" }))
+}
+
+export function assetPreviewManifest() {
+    return {
+        name: "asset-preview-manifest",
+        resolveId(id) {
+            if (id === virtualModuleId) return resolvedVirtualModuleId
+            return undefined
+        },
+        load(id) {
+            if (id !== resolvedVirtualModuleId) return undefined
+
+            const manifest = {
+                creatures: collectAssets("creatures"),
+                portraits: collectAssets("portraits"),
+                fx: collectAssets("fx"),
+            }
+
+            return `export default ${JSON.stringify(manifest, null, 2)}`
+        },
+    }
+}

--- a/vite/config.dev.mjs
+++ b/vite/config.dev.mjs
@@ -1,11 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { assetPreviewManifest } from './assetPreviewManifest.mjs'
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: './',
     plugins: [
         react(),
+        assetPreviewManifest(),
     ],
     server: {
         port: 8080

--- a/vite/config.prod.mjs
+++ b/vite/config.prod.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { assetPreviewManifest } from './assetPreviewManifest.mjs';
 
 const phasermsg = () => {
     return {
@@ -21,6 +22,7 @@ export default defineConfig({
     base: './',
     plugins: [
         react(),
+        assetPreviewManifest(),
         phasermsg()
     ],
     logLevel: 'warning',


### PR DESCRIPTION
## Resumo
- adiciona rota /preview para visualizar creatures, portraits e FX
- cria manifest Vite para listar assets públicos automaticamente
- renderiza spritesheets SVG animadas em uma instância Phaser isolada
- adiciona testes para parsing/build da rota de preview

## Validação
- pnpm exec vitest run __tests__/preview/previewRoute.test.ts
- pnpm build-nolog